### PR TITLE
Fix permissions issue with Caddy image

### DIFF
--- a/openshift/templates/aries-endorser-proxy/aries-endorser-proxy-build.yaml
+++ b/openshift/templates/aries-endorser-proxy/aries-endorser-proxy-build.yaml
@@ -1,7 +1,7 @@
 kind: Template
 apiVersion: template.openshift.io/v1
 metadata:
-  name: ${NAME}-imagestream-template
+  name: ${NAME}-build-template
 objects:
   - kind: ImageStream
     apiVersion: v1
@@ -11,16 +11,30 @@ objects:
         name: ${NAME}
         app: ${APP_NAME}
         app-group: ${APP_GROUP}
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        app-group: ${APP_GROUP}
     spec:
-      runPolicy: SerialLatestOnly
-      tags:
-        - name: ${OUTPUT_IMAGE_TAG}
-          annotations: null
-          from:
-            kind: ${SOURCE_IMAGE_KIND}
-            name: ${SOURCE_IMAGE_REGISTRY}${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
-          importPolicy:
-            scheduled: true
+      triggers:
+        - type: ImageChange
+        - type: ConfigChange
+      runPolicy: Serial
+      strategy:
+        type: Docker
+      source:
+        dockerfile: >
+          FROM ${SOURCE_IMAGE_REGISTRY}${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
+          
+          RUN chown 1001:root /usr/bin/caddy
+      output:
+        to:
+          kind: ImageStreamTag
+          name: ${NAME}:${OUTPUT_IMAGE_TAG}
 parameters:
   - name: NAME
     displayName: Name
@@ -42,11 +56,6 @@ parameters:
     description: The tag given to the built image.
     required: true
     value: latest
-  - name: SOURCE_IMAGE_KIND
-    displayName: Source Image Kind
-    description: The 'kind' (type) of the  source image; typically ImageStreamTag, or DockerImage.
-    required: true
-    value: DockerImage
   - name: SOURCE_IMAGE_NAME
     displayName: Source Image Name
     description: The name of the source image.


### PR DESCRIPTION
- Between version 2.6.2 and 2.6.3 there were some permissions changes no the official images that stopped them from working on OpenShift.
- These updates resolve the permissions issue for OCP.