### PR TITLE
Add endorsement rules for Sovrin MainNet/TestNet

### DIFF
--- a/configurations/sovrin/prod/allowed-credential-definition.csv
+++ b/configurations/sovrin/prod/allowed-credential-definition.csv
@@ -1,0 +1,5 @@
+issuer_did,author_did,schema_name,version,tag,rev_reg_def,rev_reg_entry,details
+4xE68b6S5VRFrKMMG1U95M,4xE68b6S5VRFrKMMG1U95M,Practicing Certificate,1.0.0,default,TRUE,TRUE,
+4xE68b6S5VRFrKMMG1U95M,4xE68b6S5VRFrKMMG1U95M,Member Card,1.4.0,default,TRUE,TRUE,
+4xE68b6S5VRFrKMMG1U95M,4xE68b6S5VRFrKMMG1U95M,Member Card,1.5.0,default,TRUE,TRUE,
+4xE68b6S5VRFrKMMG1U95M,4xE68b6S5VRFrKMMG1U95M,Member Card,1.5.1,default,TRUE,TRUE,

--- a/configurations/sovrin/prod/allowed-did.csv
+++ b/configurations/sovrin/prod/allowed-did.csv
@@ -1,0 +1,2 @@
+registered_did,details
+4xE68b6S5VRFrKMMG1U95M,Law Society of BC

--- a/configurations/sovrin/prod/allowed-schema.csv
+++ b/configurations/sovrin/prod/allowed-schema.csv
@@ -1,0 +1,5 @@
+author_did,schema_name,version,details
+4xE68b6S5VRFrKMMG1U95M,Practicing Certificate,1.0.0,
+4xE68b6S5VRFrKMMG1U95M,Member Card,1.4.0,
+4xE68b6S5VRFrKMMG1U95M,Member Card,1.5.0,
+4xE68b6S5VRFrKMMG1U95M,Member Card,1.5.1,

--- a/configurations/sovrin/test/allowed-credential-definition.csv
+++ b/configurations/sovrin/test/allowed-credential-definition.csv
@@ -1,0 +1,7 @@
+issuer_did,author_did,schema_name,version,tag,rev_reg_def,rev_reg_entry,details
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.0.0,default,TRUE,TRUE,
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.2.0,default,TRUE,TRUE,
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.3.0,default,TRUE,TRUE,
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Card,1.4.0,default,TRUE,TRUE,
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Card,1.5.0,default,TRUE,TRUE,
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Card,1.5.1,default,TRUE,TRUE,

--- a/configurations/sovrin/test/allowed-credential-definition.csv
+++ b/configurations/sovrin/test/allowed-credential-definition.csv
@@ -1,7 +1,7 @@
 issuer_did,author_did,schema_name,version,tag,rev_reg_def,rev_reg_entry,details
 AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.0.0,default,TRUE,TRUE,
 AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.2.0,default,TRUE,TRUE,
-AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.3.0,default,TRUE,TRUE,
+AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Certificate,1.3.0,default,TRUE,TRUE,
 AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Card,1.4.0,default,TRUE,TRUE,
 AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Card,1.5.0,default,TRUE,TRUE,
 AuJrigKQGRLJajKAebTgWu,AuJrigKQGRLJajKAebTgWu,Member Card,1.5.1,default,TRUE,TRUE,

--- a/configurations/sovrin/test/allowed-did.csv
+++ b/configurations/sovrin/test/allowed-did.csv
@@ -1,0 +1,2 @@
+registered_did,details
+AuJrigKQGRLJajKAebTgWu,Law Society of BC

--- a/configurations/sovrin/test/allowed-schema.csv
+++ b/configurations/sovrin/test/allowed-schema.csv
@@ -1,0 +1,7 @@
+author_did,schema_name,version,details
+AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.0.0,
+AuJrigKQGRLJajKAebTgWu,Practicing Certificate,1.2.0,
+AuJrigKQGRLJajKAebTgWu,Member Certificate,1.3.0,
+AuJrigKQGRLJajKAebTgWu,Member Card,1.4.0,
+AuJrigKQGRLJajKAebTgWu,Member Card,1.5.0,
+AuJrigKQGRLJajKAebTgWu,Member Card,1.5.1,


### PR DESCRIPTION
Added rules for endorsing transactions on TestNet and MainNet (LSBC agent only). Rules account for the history of what was endorsed so far.