### PR TITLE
Add CANdy dev rules for NB and LTSA

### DIFF
--- a/configurations/CAndy/dev/allowed-credential-definition.csv
+++ b/configurations/CAndy/dev/allowed-credential-definition.csv
@@ -1,4 +1,6 @@
 schema_issuer_did,creddef_author_did,schema_name,version,tag,rev_reg_def,rev_reg_entry,details
 9defyjkM6MX5zh2D5Mwo1U,RSDAVyaiUjFPCj245PoY3P,contractor-credential,*,*,True,True,Contractor Credential for CSB
 RCnz8GcyZ2iH7VFr5zGb9N,RCnz8GcyZ2iH7VFr5zGb9N,*,*,*,True,True,LSBC development and prototyping
-KKSXjEHUPVNGYHuof1J3xy,KKSXjEHUPVNGYHuof1J3xy,*,*,*,True,True,LTSA development and prototyping
+KKSXjEHUPVNGYHuof1J3xy,KKSXjEHUPVNGYHuof1J3xy,*,*,*,True,True,LTSA sandbox development and prototyping
+XpgeQa93eZvGSZBZef3PHn,Huw3C9bARcgZjYYWdU4EE8,Person,0.2,*,True,True,Northern Block development and prototyping
+MoWLSgdZLuXUKXbRM9fbh9,MoWLSgdZLuXUKXbRM9fbh9,*,*,*,True,True,LTSA development and prototyping

--- a/configurations/CAndy/dev/allowed-did.csv
+++ b/configurations/CAndy/dev/allowed-did.csv
@@ -2,4 +2,6 @@ registered_did,details
 9defyjkM6MX5zh2D5Mwo1U,BC Cyber Security and Digital Trust
 RSDAVyaiUjFPCj245PoY3P,BC Court Services
 RCnz8GcyZ2iH7VFr5zGb9N,The Law Society of British Columbia
-KKSXjEHUPVNGYHuof1J3xy,Land Title and Survey Authority of British Columbia
+KKSXjEHUPVNGYHuof1J3xy,Land Title and Survey Authority of British Columbia (sandbox)
+Huw3C9bARcgZjYYWdU4EE8,Northern Block Development
+MoWLSgdZLuXUKXbRM9fbh9,Land Title and Survey Authority of British Columbia

--- a/configurations/CAndy/dev/allowed-schema.csv
+++ b/configurations/CAndy/dev/allowed-schema.csv
@@ -1,4 +1,5 @@
 author_did,schema_name,version,details
 9defyjkM6MX5zh2D5Mwo1U,contractor-credential,*,https://github.com/bcgov/digital-trust-toolkit/blob/contractor-credential/docs/governance/employment/contractor-credential/governance.md#261-schema-definition
 RCnz8GcyZ2iH7VFr5zGb9N,*,*,LSBC development and prototyping
-KKSXjEHUPVNGYHuof1J3xy,*,*,LTSA development and prototyping
+KKSXjEHUPVNGYHuof1J3xy,*,*,LTSA sandbox development and prototyping
+MoWLSgdZLuXUKXbRM9fbh9,*,*,LTSA development and prototyping


### PR DESCRIPTION
Adds configurations for Northern Block development issuer and another LTSA agent (provisioned by Northern Block).

The NB agent is restricted to creating creddefs based on the dev person credential as they will be using them for development and testing.

Configurations have not yet been applied.