### PR TITLE
LTSA endorsement rules for test/prod

### DIFF
--- a/configurations/CAndy/prod/allowed-credential-definition.csv
+++ b/configurations/CAndy/prod/allowed-credential-definition.csv
@@ -11,4 +11,4 @@ XqaRXJt4sXE6TRpfGpVbGw,XqaRXJt4sXE6TRpfGpVbGw,app_attestation,1.0,bcwallet,True,
 B8B9jho4L57A1f6MmXpAbu,EmX9iHJrL7R6MBLH38QYp,contractor-credential,1.0,*,True,True,Contractor Credential for CSB
 QzLYGuAebsy3MXQ6b1sFiT,QzLYGuAebsy3MXQ6b1sFiT,legal-professional,1.0,lawyer,True,True,LSBC Lawyer Credential
 R12pguaP3VF2WiE6vAsiPF,R12pguaP3VF2WiE6vAsiPF,Rental Property Business Licence,1.0,Rental Property Business Licence,True,True,City of Vancouver Rental Property Business Licence Credential
-JqrH76X8ETpUaNx6TTiP4i,JqrH76X8ETpUaNx6TTiP4i,property-owner,1.1.0,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential
+JqrH76X8ETpUaNx6TTiP4i,JqrH76X8ETpUaNx6TTiP4i,property-owner,1.0.4,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential

--- a/configurations/CAndy/prod/allowed-credential-definition.csv
+++ b/configurations/CAndy/prod/allowed-credential-definition.csv
@@ -11,3 +11,4 @@ XqaRXJt4sXE6TRpfGpVbGw,XqaRXJt4sXE6TRpfGpVbGw,app_attestation,1.0,bcwallet,True,
 B8B9jho4L57A1f6MmXpAbu,EmX9iHJrL7R6MBLH38QYp,contractor-credential,1.0,*,True,True,Contractor Credential for CSB
 QzLYGuAebsy3MXQ6b1sFiT,QzLYGuAebsy3MXQ6b1sFiT,legal-professional,1.0,lawyer,True,True,LSBC Lawyer Credential
 R12pguaP3VF2WiE6vAsiPF,R12pguaP3VF2WiE6vAsiPF,Rental Property Business Licence,1.0,Rental Property Business Licence,True,True,City of Vancouver Rental Property Business Licence Credential
+JqrH76X8ETpUaNx6TTiP4i,JqrH76X8ETpUaNx6TTiP4i,property-owner,1.1.0,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential

--- a/configurations/CAndy/prod/allowed-did.csv
+++ b/configurations/CAndy/prod/allowed-did.csv
@@ -8,4 +8,5 @@ XqaRXJt4sXE6TRpfGpVbGw,BC Wallet
 B8B9jho4L57A1f6MmXpAbu,BC Cyber Security and Digital Trust
 EmX9iHJrL7R6MBLH38QYp,BC Court Services
 QzLYGuAebsy3MXQ6b1sFiT,The Law Society of British Columbia
-R12pguaP3VF2WiE6vAsiPF, City of Vancouver
+R12pguaP3VF2WiE6vAsiPF,City of Vancouver
+JqrH76X8ETpUaNx6TTiP4i,Land Title and Survey Authority of British Columbia

--- a/configurations/CAndy/prod/allowed-schema.csv
+++ b/configurations/CAndy/prod/allowed-schema.csv
@@ -9,4 +9,4 @@ XqaRXJt4sXE6TRpfGpVbGw,app_attestation,1.0,
 B8B9jho4L57A1f6MmXpAbu,contractor-credential,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/employment/contractor-credential/governance
 QzLYGuAebsy3MXQ6b1sFiT,legal-professional,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/justice/legal-professional/governance
 R12pguaP3VF2WiE6vAsiPF,Rental Property Business Licence,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/rental-property-business-licence
-JqrH76X8ETpUaNx6TTiP4i,property-owner,1.1.0,
+JqrH76X8ETpUaNx6TTiP4i,property-owner,1.0.4,

--- a/configurations/CAndy/prod/allowed-schema.csv
+++ b/configurations/CAndy/prod/allowed-schema.csv
@@ -9,3 +9,4 @@ XqaRXJt4sXE6TRpfGpVbGw,app_attestation,1.0,
 B8B9jho4L57A1f6MmXpAbu,contractor-credential,1.0,https://github.com/bcgov/digital-trust-toolkit/blob/contractor-credential/docs/governance/employment/contractor-credential/governance.md#261-schema-definition
 QzLYGuAebsy3MXQ6b1sFiT,legal-professional,1.0,https://github.com/bcgov/digital-trust-toolkit/blob/lsbc-governance/docs/governance/justice/legal-professional/governance.md
 R12pguaP3VF2WiE6vAsiPF,Rental Property Business Licence,1.0,
+JqrH76X8ETpUaNx6TTiP4i,property-owner,1.1.0,

--- a/configurations/CAndy/prod/allowed-schema.csv
+++ b/configurations/CAndy/prod/allowed-schema.csv
@@ -1,12 +1,12 @@
 author_did,schema_name,version,details
-RGjWbW1eycP7FrMf4QJvX8,Person,1.0,
+RGjWbW1eycP7FrMf4QJvX8,Person,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/person/person-cred-doc
 E2h4RUJxyh48PLJ1CtGJrq,BC VC Pilot Certificate,1.0.1,
 A2UZSmrL9N5FDZGPu68wy,bc-mines-act-permit,1.0,
-AcZpBDz3oxmKrpcuPcdKai,Digital Business Card,1.0.0,
-A2UZSmrL9N5FDZGPu68wy,bc-mines-act-permit,1.1.1,
+AcZpBDz3oxmKrpcuPcdKai,Digital Business Card,1.0.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/digital-business-card-v1
+A2UZSmrL9N5FDZGPu68wy,bc-mines-act-permit,1.1.1,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/mining/bc-mines-act-permit/1.1.1/governance/
 XqaRXJt4sXE6TRpfGpVbGw,app_attestation,1.0,
 4WW6792ksq62UroZyfd6nQ,LCRBSirSes,1.0.0,
-B8B9jho4L57A1f6MmXpAbu,contractor-credential,1.0,https://github.com/bcgov/digital-trust-toolkit/blob/contractor-credential/docs/governance/employment/contractor-credential/governance.md#261-schema-definition
-QzLYGuAebsy3MXQ6b1sFiT,legal-professional,1.0,https://github.com/bcgov/digital-trust-toolkit/blob/lsbc-governance/docs/governance/justice/legal-professional/governance.md
-R12pguaP3VF2WiE6vAsiPF,Rental Property Business Licence,1.0,
+B8B9jho4L57A1f6MmXpAbu,contractor-credential,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/employment/contractor-credential/governance
+QzLYGuAebsy3MXQ6b1sFiT,legal-professional,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/justice/legal-professional/governance
+R12pguaP3VF2WiE6vAsiPF,Rental Property Business Licence,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/rental-property-business-licence
 JqrH76X8ETpUaNx6TTiP4i,property-owner,1.1.0,

--- a/configurations/CAndy/test/allowed-credential-definition.csv
+++ b/configurations/CAndy/test/allowed-credential-definition.csv
@@ -7,3 +7,4 @@ KCxVC8GkKywjhWJnUfCmkW,KCxVC8GkKywjhWJnUfCmkW,Person,1.0,*,True,True,BC Person Q
 KCxVC8GkKywjhWJnUfCmkW,LbeM3m8SVix4uhdVPyVAQe,Person,1.0,*,True,True,BC Person Preprod
 MLvtJW6pFuYu4NnMB14d29,MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,lawyer,True,True,LSBC Lawyer Credential
 ARK5s3QZtjL5X65mLoubdk,ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,Rental Property Business Licence,True,True,City of Vancouver Rental Property Business Licence Credential
+Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.1.0,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential

--- a/configurations/CAndy/test/allowed-credential-definition.csv
+++ b/configurations/CAndy/test/allowed-credential-definition.csv
@@ -7,5 +7,7 @@ KCxVC8GkKywjhWJnUfCmkW,KCxVC8GkKywjhWJnUfCmkW,Person,1.0,*,True,True,BC Person Q
 KCxVC8GkKywjhWJnUfCmkW,LbeM3m8SVix4uhdVPyVAQe,Person,1.0,*,True,True,BC Person Preprod
 MLvtJW6pFuYu4NnMB14d29,MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,lawyer,True,True,LSBC Lawyer Credential
 ARK5s3QZtjL5X65mLoubdk,ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,Rental Property Business Licence,True,True,City of Vancouver Rental Property Business Licence Credential
-Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.0.4,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential (Staging)
-Tm3dXMR3UsSU4X9Ew913Um,2GtQ574ofyB9tPFtjjcV6p,property-owner,1.0.4,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential (UAT)
+Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.0.4,property-owner,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential (Staging)
+Tm3dXMR3UsSU4X9Ew913Um,2GtQ574ofyB9tPFtjjcV6p,property-owner,1.0.4,property-owner,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential (UAT)
+Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,legal-professional,1.0,lawyer,True,True,Land Title and Survey Authority of British Columbia Legal Professional Credential (Staging)
+Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,Person,1.0,Person,True,True,Land Title and Survey Authority of British Columbia Person Credential (Staging)

--- a/configurations/CAndy/test/allowed-credential-definition.csv
+++ b/configurations/CAndy/test/allowed-credential-definition.csv
@@ -7,4 +7,5 @@ KCxVC8GkKywjhWJnUfCmkW,KCxVC8GkKywjhWJnUfCmkW,Person,1.0,*,True,True,BC Person Q
 KCxVC8GkKywjhWJnUfCmkW,LbeM3m8SVix4uhdVPyVAQe,Person,1.0,*,True,True,BC Person Preprod
 MLvtJW6pFuYu4NnMB14d29,MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,lawyer,True,True,LSBC Lawyer Credential
 ARK5s3QZtjL5X65mLoubdk,ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,Rental Property Business Licence,True,True,City of Vancouver Rental Property Business Licence Credential
-Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.1.0,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential
+Tm3dXMR3UsSU4X9Ew913Um,Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.0.4,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential (Staging)
+Tm3dXMR3UsSU4X9Ew913Um,2GtQ574ofyB9tPFtjjcV6p,property-owner,1.0.4,Property Owner Credential,True,True,Land Title and Survey Authority of British Columbia Property Owner Credential (UAT)

--- a/configurations/CAndy/test/allowed-did.csv
+++ b/configurations/CAndy/test/allowed-did.csv
@@ -8,4 +8,5 @@ LbeM3m8SVix4uhdVPyVAQe,IDIM Agent (PreProd)
 KCxVC8GkKywjhWJnUfCmkW,IDIM Agent (QA)
 MLvtJW6pFuYu4NnMB14d29,The Law Society of British Columbia
 ARK5s3QZtjL5X65mLoubdk,City of Vancouver (Test)
-Tm3dXMR3UsSU4X9Ew913Um,Land Title and Survey Authority of British Columbia
+Tm3dXMR3UsSU4X9Ew913Um,Land Title and Survey Authority of British Columbia (Staging)
+2GtQ574ofyB9tPFtjjcV6p,Land Title and Survey Authority of British Columbia (UAT)

--- a/configurations/CAndy/test/allowed-did.csv
+++ b/configurations/CAndy/test/allowed-did.csv
@@ -8,3 +8,4 @@ LbeM3m8SVix4uhdVPyVAQe,IDIM Agent (PreProd)
 KCxVC8GkKywjhWJnUfCmkW,IDIM Agent (QA)
 MLvtJW6pFuYu4NnMB14d29,The Law Society of British Columbia
 ARK5s3QZtjL5X65mLoubdk,City of Vancouver (Test)
+Tm3dXMR3UsSU4X9Ew913Um,Land Title and Survey Authority of British Columbia

--- a/configurations/CAndy/test/allowed-schema.csv
+++ b/configurations/CAndy/test/allowed-schema.csv
@@ -1,8 +1,9 @@
 author_did,schema_name,version,details
-BQu1v6o9Z9ttkdwbVqpyZB,contractor-credential,*,https://github.com/bcgov/digital-trust-toolkit/blob/contractor-credential/docs/governance/employment/contractor-credential/governance.md#261-schema-definition
+BQu1v6o9Z9ttkdwbVqpyZB,contractor-credential,*,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/employment/contractor-credential/governance
 Ttmj1pEotg8FbKZZD81S7i,LCRBSirSes,1.0.0,T.B.D.
-K9igebFysBL6jcBwR8bKuN,Digital Business Card,1.0.0,T.B.D.
+K9igebFysBL6jcBwR8bKuN,Digital Business Card,1.0.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/digital-business-card-v1
 RycQpZ9b4NaXuT5ZGjXkUE,app_attestation,1.0,T.B.D.
-KCxVC8GkKywjhWJnUfCmkW,Person,1.0,T.B.D.
-MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,https://github.com/bcgov/digital-trust-toolkit/blob/lsbc-governance/docs/governance/justice/legal-professional/governance.md
-ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,T.B.D.
+KCxVC8GkKywjhWJnUfCmkW,Person,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/person/person-cred-doc
+MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/justice/legal-professional/governance
+ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/rental-property-business-licence
+Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.1.0,Property Owner Credential

--- a/configurations/CAndy/test/allowed-schema.csv
+++ b/configurations/CAndy/test/allowed-schema.csv
@@ -6,4 +6,4 @@ RycQpZ9b4NaXuT5ZGjXkUE,app_attestation,1.0,T.B.D.
 KCxVC8GkKywjhWJnUfCmkW,Person,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/person/person-cred-doc
 MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/justice/legal-professional/governance
 ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/rental-property-business-licence
-Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.1.0,Property Owner Credential
+Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.0.4,Property Owner Credential

--- a/configurations/CAndy/test/allowed-schema.csv
+++ b/configurations/CAndy/test/allowed-schema.csv
@@ -7,3 +7,5 @@ KCxVC8GkKywjhWJnUfCmkW,Person,1.0,https://developer.gov.bc.ca/docs/default/compo
 MLvtJW6pFuYu4NnMB14d29,legal-professional,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/justice/legal-professional/governance
 ARK5s3QZtjL5X65mLoubdk,Rental Property Business Licence,1.0,https://developer.gov.bc.ca/docs/default/component/digital-trust/governance/business/rental-property-business-licence
 Tm3dXMR3UsSU4X9Ew913Um,property-owner,1.0.4,Property Owner Credential
+Tm3dXMR3UsSU4X9Ew913Um,legal-professional,1.0,Legal Professional LTSA Mock
+Tm3dXMR3UsSU4X9Ew913Um,Person,1.0,Person LTSA Mock


### PR DESCRIPTION
Adding endorsement rules for LTSA `test` and `prod`.

Leaving PR in draft mode until the latest details have been sorted out and all changes have been applied to the environments.